### PR TITLE
docs: update license year to 2026 (fixes #27)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Gregor Kobilarov
+Copyright (c) 2026 Gregor Kobilarov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the copyright year in the LICENSE file. Fixes #27